### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -10,6 +10,11 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 jobs:
   ubuntu-latest:
     name: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dendrodocs/dotnet-client-lib/security/code-scanning/1](https://github.com/dendrodocs/dotnet-client-lib/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- `contents: read` is required for actions like `actions/checkout` and `actions/cache`.
- `packages: write` may be required for publishing packages or interacting with package feeds.
- `actions: write` may be required for uploading artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`ubuntu-latest`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
